### PR TITLE
Fix: buffer.readUInt8 is not a function

### DIFF
--- a/lib/pomelo-client.js
+++ b/lib/pomelo-client.js
@@ -400,7 +400,7 @@
       route = msg.route = abbrs[route];
     }
     if(protobuf && serverProtos[route]) {
-      return protobuf.decode(route, msg.body);
+      return protobuf.decodeStr(route, msg.body);
     } else if(decodeIO_decoder && decodeIO_decoder.lookup(route)) {
       return decodeIO_decoder.build(route).decode(msg.body);
     } else {


### PR DESCRIPTION
最新的protobuf，使用 decodeStr 方法才会把msg.body包装成buffer

测试可以解决这个issue，https://github.com/NetEase/pomelo-cocos2d-js/issues/13
